### PR TITLE
Adding collect volumes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# MAGeTbrain Pipeline
+
+A Nextflow implementation of the [Multiple Automatically Generated Templates (MAGeT) brain](https://github.com/CobraLab/MAGeTbrain) segmentation pipeline.
+
+> Pipitone J, Park MT, Winterburn J, et al. Multi-atlas segmentation of the whole hippocampus
+> and subfields using multiple automatically generated templates. Neuroimage. 2014;
+
+> M Mallar Chakravarty, Patrick Steadman, Matthijs C van Eede, Rebecca D Calcott, Victoria Gu, Philip Shaw, Armin Raznahan, D Louis Collins, and Jason P Lerch.
+> Performing label-fusion-based segmentation using multiple automatically generated templates. Hum Brain Mapp, 34(10):2635–54, October 2013. (doi:10.1002/hbm.22092)
+
+## Prerequisites
+
+- [Nextflow](https://www.nextflow.io/) (version 20.07.1 or later)
+- [Docker](https://www.docker.com/) or [Singularity](https://sylabs.io/singularity/)
+- MINC Toolkit (provided in the Docker container) _optional_
+
+## Quick Start
+
+> [!IMPORTANT]  
+> All images should be in NIfTI format (`.nii.gz`)  
+> `.mnc` can be converted to NIfTI using `mnc2nii` from minc-toolkit-v2  
+> see below in section [Converting MINC to NIFTI](#converting-minc-to-nifti)  
+> [link to docs](https://bic-mni.github.io/man-pages/man/mnc2nii)
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/CoBrALab/MAGeTBrain-nextflow.git
+cd MAGeTBrain-nextflow
+```
+
+2. Input structure
+   Atlases and images should be structure in an input directory as follows:
+
+```bash
+inputs/
+├── atlases/
+│   ├── atlas1_T1w.nii.gz
+│   ├── atlas1_label_*.nii.gz
+│   ├── atlas2_T1w.nii.gz
+│   ├── atlas2_label_*.nii.gz
+│   └── ...
+└── subjects/
+    ├── subject1_T1w.nii.gz
+    ├── subject2_T1w.nii.gz
+    └── ...
+```
+
+## Converting MINC to NIFTI
+
+A docker image can be pulled with the minc-toolkit-v2
+
+```bash
+docker pull nistmni/minc-toolkit:1.9.16
+# next mount your volumne in the container
+docker run -it -v /path/to/dir:/home/nistmni/input
+# now you should be in the docker shell
+# add the toolkit bin to the path
+export PATH=$PATH:/opt/minc/1.9.16/bin
+# next perform the conversion
+mnc2nii input.mnc output.nii
+```
+
+The `.nii` files will now be in the directory where the original `.mnc` files were.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ A Nextflow implementation of the [Multiple Automatically Generated Templates (MA
 > [!IMPORTANT]  
 > All images should be in NIfTI format (`.nii.gz`)  
 > `.mnc` can be converted to NIfTI using `mnc2nii` from minc-toolkit-v2  
-> see below in section [Converting MINC to NIFTI](#converting-minc-to-nifti)  
 > [link to docs](https://bic-mni.github.io/man-pages/man/mnc2nii)
 
 1. Clone the repository:
@@ -30,35 +29,33 @@ cd MAGeTBrain-nextflow
 ```
 
 2. Input structure
-   Atlases and images should be structure in an input directory as follows:
+   Atlases, templates and subjects need to be in a specific structure in the `inputs` directory.
+   Optionally labels for each `<atlasname>_label_<labelname1.nii.gz` should be included in a `labels` directory.
+   These optional labels are for collecting the volumes of the majority votes.
+   Atlases, templates, subjects and Optionally labels should be structure in an input directory as follows:
 
 ```bash
-inputs/
-├── atlases/
-│   ├── atlas1_T1w.nii.gz
-│   ├── atlas1_label_*.nii.gz
-│   ├── atlas2_T1w.nii.gz
-│   ├── atlas2_label_*.nii.gz
+inputs
+├── atlases
+│   ├── atlas1_label_<labelname1>.nii.gz
+│   ├── atlas1_label_<labelname2>.nii.gz
+│   ├── atlas1_T1w.nii.gz
 │   └── ...
-└── subjects/
-    ├── subject1_T1w.nii.gz
-    ├── subject2_T1w.nii.gz
+├── subjects
+│   ├── subject1_T1w.nii.gz
+│   ├── subject2_T1w.nii.gz
+│   ├── subject3_T1w.nii.gz
+│   ├── subject4_T1w.nii.gz
+│   ├── subject5_T1w.nii.gz
+│   └── ...
+├── templates
+│   ├── subject2_T1w.nii.gz
+│   ├── subject5_T1w.nii.gz
+│   └── ...
+└── labels
+    ├── <labelname1>_volume_labels.csv
+    ├── <labelname2>_volume_labels.csv
     └── ...
 ```
 
-## Converting MINC to NIFTI
-
-A docker image can be pulled with the minc-toolkit-v2
-
-```bash
-docker pull nistmni/minc-toolkit:1.9.16
-# next mount your volumne in the container
-docker run -it -v /path/to/dir:/home/nistmni/input
-# now you should be in the docker shell
-# add the toolkit bin to the path
-export PATH=$PATH:/opt/minc/1.9.16/bin
-# next perform the conversion
-mnc2nii input.mnc output.nii
-```
-
-The `.nii` files will now be in the directory where the original `.mnc` files were.
+3. When the `inputs` directory has been set-up as above the workflow can be run with the following command `nextflow magetbrain.nf`

--- a/README.md
+++ b/README.md
@@ -30,9 +30,17 @@ cd MAGeTBrain-nextflow
 
 2. Input structure
    Atlases, templates and subjects need to be in a specific structure in the `inputs` directory.
-   Optionally labels for each `<atlasname>_label_<labelname1.nii.gz` should be included in a `labels` directory.
+   Optionally labels for each `<atlasname>_label_<labelname1>.nii.gz` should be included in a `labels` directory.
    These optional labels are for collecting the volumes of the majority votes.
    Atlases, templates, subjects and Optionally labels should be structure in an input directory as follows:
+
+> [!IMPORTANT]  
+> A note about labels for use with `collect_volumes_nifti_sh`
+> Nextflow uses regex to match `volume_label_<label>.csv` to the corresponding majorityVote ouput
+> Specifically it matches on `\w`, that is any letter, digit or underscore. Equivalent to [a-zA-Z0-9_].
+> /_label_([\w]+)\.nii.gz/
+> \_This means only alphanumerical characters can be used\_
+> other characters like `-  , . < >` etc will cause errors
 
 ```bash
 inputs
@@ -53,8 +61,8 @@ inputs
 │   ├── subject5_T1w.nii.gz
 │   └── ...
 └── labels
-    ├── <labelname1>_volume_labels.csv
-    ├── <labelname2>_volume_labels.csv
+    ├── volume_labels_<labelname1>.csv
+    ├── volume_labels_<labelname2>.csv
     └── ...
 ```
 

--- a/bin/collect_volumes_nifti.sh
+++ b/bin/collect_volumes_nifti.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Script to collect volumes in parallel, and use names from a csv if available
+# Modified to work with NIFTI files and use LabelGeometryMeasures
+# CSV Format
+# 1,name
+# 2,name
+# etc
+
+set -euo pipefail
+
+firstarg=${1:-}
+if ! [[  ( $firstarg = *csv ) ||  ( $firstarg = *nii ) || ( $firstarg = *nii.gz ) ]]; then
+    echo "usage: $0 [ label-mapping.csv ] input.nii.gz [ input2.nii.gz ... inputN.nii.gz ]"
+    exit 1
+fi
+
+output_file="collected_volumes.tsv"
+label_csv=""
+
+if [[ "$1" == *csv ]]; then
+    label_csv="$1"
+    shift
+fi
+
+temp_dir=$(mktemp -d)
+echo "Using temporary directory: $temp_dir"
+# rm on exit
+trap 'rm -rf "$temp_dir"' EXIT
+
+for file in "$@"; do
+    # strip suffix
+    file_basename=$(basename "$file")
+    result_file="$temp_dir/${file_basename}.out"
+    
+    echo "Processing $file..."
+    
+    LabelGeometryMeasures 3 "$file" "none" > "$result_file"
+    
+    awk -v file="$file" 'NR==1 {print "Subject\t" $0; next} {print file "\t" $0}' "$result_file" > "${result_file}.with_subject"
+    
+    # If we have a label CSV, merge it with the output based on label number
+    if [ -n "$label_csv" ] && [ -f "$label_csv" ]; then
+        # Create a temporary file with the label mappings
+        awk -F, '{print $1 "," $2}' "$label_csv" > "$temp_dir/label_map.csv"
+        
+        # Merge the label information with the LabelGeometryMeasures output
+        awk -v label_file="$temp_dir/label_map.csv" '
+        BEGIN {
+            # Read the label mapping file
+            while ((getline line < label_file) > 0) {
+                split(line, parts, ",");
+                label_num = parts[1];
+                label_name = parts[2];
+                labels[label_num] = label_name;
+            }
+            close(label_file);
+            
+            # Add header for label number and name
+            OFS = "\t";
+        }
+        NR == 1 {
+            print "LabelNumber", "LabelName", $0;
+            next;
+        }
+        {
+            # Extract the label number from the second column
+            label_num = $2;
+            if (label_num in labels) {
+                label_text = labels[label_num];
+            } else {
+                label_text = "Unknown";
+            }
+            print label_num, label_text, $0;
+        }' "${result_file}.with_subject" > "${result_file}.final"
+    else
+        # No label CSV, just add empty columns
+        awk 'NR==1 {print "LabelNumber\tLabelName\t" $0; next} {print $2 "\tUnknown\t" $0}' "${result_file}.with_subject" > "${result_file}.final"
+    fi
+    
+    if [ ! -f "$output_file" ]; then
+        cat "${result_file}.final" > "$output_file"
+    else
+        tail -n +2 "${result_file}.final" >> "$output_file"
+    fi
+done
+
+echo "Processing complete. Results saved to $output_file"

--- a/magetbrain.nf
+++ b/magetbrain.nf
@@ -175,25 +175,42 @@ process collectVolumes {
   // memory '16GB'
   // time '30min'
 
-  publishDir "${params.outputDir}/labels/majorityvote/collectVolumes" 
 
   input:
-    path labelCsv
-    path input
+    tuple path(labelCsv), path(input)  
 
   output:
-    path "collected_volumes.tsv"
+    path "${input.baseName}_volume_output.tsv"
 
   script:
+    
     def labelCsvArg = labelCsv.name != 'NO_FILE' ? "${labelCsv}" : ""
     """
-    collect_volumes_nifti.sh ${labelCsvArg} ${input}
+    collect_volumes_nifti.sh ${labelCsvArg} ${input} > ${input.baseName}_volume_output.tsv
     """
 
   stub:
     def labelCsvArg = labelCsv.name != 'NO_FILE' ? "${labelCsv}" : ""
     """
-    echo collect_volumes_nifti.sh ${labelCsvArg} ${input}
+    echo collect_volumes_nifti.sh ${labelCsvArg} ${input} > volume_output.tsv
+    """
+}
+
+process combineVolumes {
+
+  publishDir path:"${params.outputDir}/labels/majorityvote/collectVolumes"
+
+  input:
+    path files 
+  output:
+    path "combined_volume_output.tsv"
+
+  script:
+    """
+    cat ${files[0]} > combined_volume_output.tsv
+    for file in ${files.tail().join(" ")}; do
+        tail -n +2 \$file >> combined_volume_output.tsv
+    done
     """
 }
 
@@ -273,33 +290,46 @@ workflow MAGeTBrain {
 
     
 }
+
 workflow {
   // Read in atlas files, use primarySpectra option to determine which will be the primary match
   // map the filename to a subject ID for later use
   def atlases = Channel.fromPath('inputs/atlases/*_' + params.primarySpectra + '.nii.gz')
                       .map { file -> tuple(file.simpleName.minus('_' + params.primarySpectra), file) }
   // Read in labels
-  // map the filename to a subject ID for later use
   def labels = Channel.fromPath( 'inputs/atlases/*_label_*.nii.gz' )
                       .map { file -> tuple(file.simpleName - ~/_label.*/, (file.simpleName =~ /_label.*/)[0], file) }
   // Read in templates
-  // map the filename to a subject ID for later use
   def templates = Channel.fromPath('inputs/templates/*_' + params.primarySpectra + '.nii.gz')
                       .map { file -> tuple(file.simpleName.minus('_' + params.primarySpectra), file) }
   // Read in subjects
-  // map the filename to a subject ID for later use
   def subjects = Channel.fromPath( 'inputs/subjects/*_' + params.primarySpectra + '.nii.gz' )
                       .map { file -> tuple(file.simpleName.minus('_' + params.primarySpectra), file) }
-
-  // Optional labels.csv for collect_volumes_nifti.sh
-  def labelsCSV = file("${params.inputDir}/VolumeLabels.csv").exists() ? 
-                  file("${params.inputDir}/VolumeLabels.csv") : 
-                  file("NO_FILE")
 
   // Run MAGeTBrain 
   def majorityVoteOutput = MAGeTBrain(atlases, labels, templates, subjects)
     
-  // Run volume collection
-  collectVolumes(labelsCSV, majorityVoteOutput.flatten().collect() )
-}
+    // set the majorityVoteOutput as filesToProcess and check to if a label.csv file exists
+   majorityVoteOutput 
+        .map { a_file ->
+            def matcher = a_file.name =~ /_label_([\w]+)\.nii.gz/
+            if (matcher.find()) {
+                def label = matcher.group(1)
+                def csvFile = file("${params.inputDir}/labels/volume_label_${label}.csv")
+                
+                if (csvFile.exists()) {
+                    return [csvFile, a_file]  
+                } else {
+                    return [file("NO_FILE"), a_file]  
+                }
+            } else {
+                return [null, a_file]
+            }
+        }
+        .set { filesToProcess }
+    // collect the volumes and combine results
+    volumes = collectVolumes(filesToProcess)
+    // after all files process they will be collected
+    combineVolumes(volumes.collect())
+    }
 


### PR DESCRIPTION
Added `collect_volumes.sh` and added the process to `magetbrain.nf` workflow. It will use `LabelGeomteryMeasures` to calculate volumes from the majorityVote output. It will concat all the results from each majorityVote label file. an optional `VolumeLabels.csv` can be provided in the `input/` dir which will be added to the final `collect_volumes.sh` output, `collected_volumes.tsv`.


`VolumeLabels.csv` example:
```
1, label1
2, label2
4, label4
5, label5
6, label6
34, label34
101, label101
102, label102
104, label104
105, label105
106, label106
```

`collected_volumes.tsv` example:

```
| LabelNumber | LabelName | Subject | Label | VolumeInVoxels | VolumeInMillimeters | SurfaceAreaInMillimetersSquared | Eccentricity | Elongation | Roundness | Flatness | Centroid | AxesLengths | BoundingBox |
| 1 | label1 | 2mm_sub-031274_label_.nii.gz | 1 | 48 | 384.000000 | 474.037676 | 0.986648 | 2.477908 | 0.538963 | 4.227524 | [-22.5004, 4.7696, -7.0718] | [4.0451, 17.1008, 42.3741] | [51, 50, 51, 59, 65, 60] |
| 2 | label2 | 2mm_sub-031274_label_.nii.gz | 2 | 14 | 112.000000 | 149.329301 | 0.999146 | 4.919672 | 0.752462 | 4.260210 | [-19.7087, -0.4882, -9.1015] | [2.1005, 8.9484, 44.0232] | [52, 52, 51, 57, 65, 57] |
| 4 | label4 | 2mm_sub-031274_label_.nii.gz | 4 | 84 | 672.000000 | 634.453808 | 0.993927 | 3.014538 | 0.584786 | 3.111884 | [-22.5343, 3.0258, -5.8873] | [4.2540, 13.2379, 39.9063] | [52, 50, 52, 59, 65, 59] |
| 5 | label5 | 2mm_sub-031274_label_.nii.gz | 5 | 11 | 88.000000 | 126.925950 | 0.935395 | 1.681669 | 0.753799 | 4.221855 | [-25.1063, 2.3875, -6.2574] | [4.4843, 18.9319, 31.8372] | [52, 52, 52, 60, 64, 57] |
| 6 | label6 | 2mm_sub-031274_label_.nii.gz | 6 | 8 | 64.000000 | 93.365184 | 0.998770 | 4.490472 | 0.828742 | 4.625949 | [-23.9551, 2.1032, -7.5301] | [2.4542, 11.3532, 50.9812] | [55, 50, 51, 59, 65, 58] |
| 1 | label1 | 2mm_sub-031275_label_.nii.gz | 1 | 61 | 488.000000 | 573.805182 | 0.991322 | 2.758129 | 0.522396 | 3.274313 | [-26.5699, -6.2230, -15.3647] | [4.5725, 14.9717, 41.2938] | [52, 51, 51, 60, 67, 58] |
| 2 | label2 | 2mm_sub-031275_label_.nii.gz | 2 | 12 | 96.000000 | 128.643762 | 0.994586 | 3.102097 | 0.788151 | 3.892980 | [-23.7046, -14.6847, -17.8367] | [2.4912, 9.6981, 30.0845] | [53, 53, 51, 57, 66, 57] |
| 4 | label4 | 2mm_sub-031275_label_.nii.gz | 4 | 89 | 712.000000 | 630.292058 | 0.994380 | 3.073325 | 0.611780 | 2.519319 | [-26.1377, -8.5405, -14.0320] | [4.8414, 12.1970, 37.4855] | [53, 52, 52, 60, 67, 59] |
| 5 | label5 | 2mm_sub-031275_label_.nii.gz | 5 | 11 | 88.000000 | 124.646411 | 0.994732 | 3.123321 | 0.767584 | 1.672942 | [-29.7242, -11.7908, -13.8748] | [5.5113, 9.2201, 28.7972] | [56, 55, 51, 60, 67, 56] |
| 6 | label6 | 2mm_sub-031275_label_.nii.gz | 6 | 10 | 80.000000 | 110.306291 | 0.997986 | 3.970379 | 0.813974 | 4.214218 | [-25.1298, -11.7181, -16.2322] | [3.1424, 13.2427, 52.5787] | [55, 52, 51, 59, 67, 58] |
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive user guide detailing pipeline prerequisites, setup instructions, and file conversion procedures.

- **New Features**
  - Enhanced the workflow with an automated step to collect volume data.
  - Introduced an interactive utility for cleaning up temporary and output files.

- **Chores**
  - Improved repository management by excluding unnecessary test, log, and output files from version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->